### PR TITLE
Add task to print script output

### DIFF
--- a/files/vms-before-ceph-version.sh
+++ b/files/vms-before-ceph-version.sh
@@ -88,14 +88,14 @@ done
 # In case that the ceph is not installed in the system. 
 # No prior install or update of ceph client
 if [[ -z "$CEPH_UPGRADE_TIMESTAMP" ]]; then
-    echo "Ceph is not installed in the system" 1>&2
+    echo "Ceph is not installed in the system"
     exit 0
 fi
 
 # In case that there is no prior ceph version than $CEPH_VERSION_EXPECTED. 
 # This means that the code has completed the previous loop without break.
 if version_lt_op $CEPH_VERSION_EXPECTED $CEPH_VERSION; then
-    echo "There is no Ceph version lower or equal to $CEPH_VERSION_EXPECTED is installed" 1>&2
+    echo "There is no Ceph version lower or equal to $CEPH_VERSION_EXPECTED is installed"
     exit 0
 fi
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,9 +8,15 @@
     mode: 500
   tags: script
   no_log: true
+
 - name: Run verification script
   shell: "/root/vms-before-ceph-version.sh {% if ceph_version is defined %} -v {{ ceph_version }} {% endif %}"
   changed_when: False
+  register: vms_list
+
+- name: Print script output
+  ansible.builtin.debug:
+    var: vms_list.stdout_lines
 
 - name: Clean verification script
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   register: vms_list
 
 - name: Print script output
-  ansible.builtin.debug:
+  debug:
     var: vms_list.stdout_lines
 
 - name: Clean verification script


### PR DESCRIPTION
By default the script output is printed to stdout only if ansible.cfg
has the "stdout_callback = minimal" line or if the playbook is run with
the environment variable "ANSIBLE_STDOUT_CALLBACK=minimal" defined.
This commit adds an explicit printing of the output of the script, so
that the playbook calling this role can be run without the need of
changing ansible.cfg or defining environment variables.