### PR TITLE
Improve start time logic.

### DIFF
--- a/files/vms-before-ceph-version.sh
+++ b/files/vms-before-ceph-version.sh
@@ -113,7 +113,7 @@ PIDS=$(pgrep -f "^/usr/libexec/qemu-kvm")
 
 for PID in $PIDS; do
   # Get QEMU process start time
-  QEMU_TIMESTAMP=$(date -d "$(stat -c %x /proc/$PID/stat)" +%s)
+  QEMU_TIMESTAMP=$(date -d "$(ps -p $PID -o lstart=)" +%s)
   if [[ "$QEMU_TIMESTAMP" -lt "$CEPH_UPGRADE_TIMESTAMP" ]]
   then
     # Get virsh instance ID and name


### PR DESCRIPTION
In some cases the stat command doesn't give accurate information on when the process was started.

Using the ps format we can get the launch time(lstart) of the process. lstart= ( disables title output)

This fix means that some of the old vms that ceph reported but the previous version of the tool didn't weren't captured.